### PR TITLE
Fix coverage badge generation permissions error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       run: uv run pytest --cov-report=xml
 
     - name: Generate coverage badge
+      # Only run on push events or PRs from the same repository (not external forks)
+      if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
       run: |
         # Extract coverage percentage from XML
         COVERAGE=$(python -c "
@@ -66,4 +68,26 @@ jobs:
           echo "Push failed, pulling latest changes and retrying..."
           git pull origin ${BRANCH_NAME} --rebase || git pull origin ${BRANCH_NAME} --no-rebase
           git push origin HEAD:${BRANCH_NAME}
-        fi 
+        fi
+
+    - name: Coverage report (for external PRs)
+      # Only run on external PRs where we can't update the badge
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+      run: |
+        # Extract coverage percentage from XML
+        COVERAGE=$(python -c "
+        import xml.etree.ElementTree as ET
+        tree = ET.parse('coverage.xml')
+        root = tree.getroot()
+        coverage = float(root.attrib['line-rate']) * 100
+        print(f'{coverage:.2f}')
+        ")
+        
+        echo "## Coverage Report" >> $GITHUB_STEP_SUMMARY
+        echo "Current coverage: **${COVERAGE}%**" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Note: Coverage badge cannot be updated automatically for external pull requests due to security restrictions." >> $GITHUB_STEP_SUMMARY
+        echo "The badge will be updated when this PR is merged by a maintainer." >> $GITHUB_STEP_SUMMARY
+        
+        # Output coverage to logs for visibility
+        echo "Coverage: ${COVERAGE}%" 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ uv run tests/run_coverage.py clean
 - **Coverage Source**: `mlb_api.py` and `generic_api.py`
 - **Reports**: Terminal output, HTML (`htmlcov/index.html`), and XML (`coverage.xml`)
 - **CI Integration**: Coverage checking and badge updates run automatically on every push/PR
+  - **Note**: For external pull requests (from forks), the coverage badge cannot be updated automatically due to GitHub security restrictions. Coverage information is still displayed in the workflow summary, and the badge will be updated when the PR is merged by a maintainer.
 
 ### Test Structure
 


### PR DESCRIPTION
Update CI workflow to handle coverage badge generation for external pull requests without permission errors.

Previously, the workflow attempted to push badge updates to the branch, which failed for PRs from external forks due to GitHub's security restrictions on write permissions. This change adds conditional logic to only update the badge on pushes or internal PRs, and for external PRs, it displays the coverage in the workflow summary instead.

---

[Open in Web](https://cursor.com/agents?id=bc-054cef7e-4bc4-4f40-b65e-68aaa2108dcb) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-054cef7e-4bc4-4f40-b65e-68aaa2108dcb) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)